### PR TITLE
Place model on self.device

### DIFF
--- a/evaluation_pipeline/finetune/trainer.py
+++ b/evaluation_pipeline/finetune/trainer.py
@@ -80,6 +80,9 @@ class Trainer():
         for param in self.ema_model.parameters():
             param.requires_grad = False
 
+        self.model.to(self.device)
+        self.ema_model.to(self.device)
+        
         self.tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(self.args.model_name_or_path)
 
     def load_data(self: Trainer) -> None:


### PR DESCRIPTION
Running finetuning with `cuda` is currently broken because the model is loaded to `cpu` by default. This fixes this by placing the model on `self.device`. 