### PR TITLE
Support finetuning if tokenizer has no bos_token

### DIFF
--- a/evaluation_pipeline/sentence_zero_shot/dataset.py
+++ b/evaluation_pipeline/sentence_zero_shot/dataset.py
@@ -59,9 +59,14 @@ class CompletionRankingDataset(Dataset):
             for token_idx in phrase_indices:
                 phrase_mask[token_idx] = 1
 
-            processed_sentence_dict[f'sentence_{sentence_idx}_tokens'] = torch.LongTensor(bos_index + tokens)
-            processed_sentence_dict[f'sentence_{sentence_idx}_attn_mask'] = torch.LongTensor([1] + attention_mask)
-            processed_sentence_dict[f'sentence_{sentence_idx}_phrase_mask'] = torch.LongTensor([0] + phrase_mask)
+            if bos_index[0] is not None:
+                processed_sentence_dict[f'sentence_{sentence_idx}_tokens'] = torch.LongTensor(bos_index + tokens)
+                processed_sentence_dict[f'sentence_{sentence_idx}_attn_mask'] = torch.LongTensor([1] + attention_mask)
+                processed_sentence_dict[f'sentence_{sentence_idx}_phrase_mask'] = torch.LongTensor([0] + phrase_mask)
+            else:
+                processed_sentence_dict[f'sentence_{sentence_idx}_tokens'] = torch.LongTensor(tokens)
+                processed_sentence_dict[f'sentence_{sentence_idx}_attn_mask'] = torch.LongTensor(attention_mask)
+                processed_sentence_dict[f'sentence_{sentence_idx}_phrase_mask'] = torch.LongTensor(phrase_mask)
 
         return processed_sentence_dict
 


### PR DESCRIPTION
If the tokenizer had no `bos_token_id`, the fine-tuning script would fail with:

`TypeError: 'NoneType' object cannot be interpreted as an integer`

This was due to the addition of `bos_index + tokens` in `dataset.py` without checking if `bos_index` was None. This PR adds this check to support fine-tuning for models trained without a `bos_token`.
